### PR TITLE
Update to time.process_time()

### DIFF
--- a/Fabian/image_file_series.py
+++ b/Fabian/image_file_series.py
@@ -125,10 +125,10 @@ class image_file_series:
 
 if __name__=='__main__':
   import sys,time
-  b=time.clock()
+  b=time.process_time()
   fs=image_file_series(sys.argv[1])
   print(fs.filename,fs.current(toPIL=False))
   while next(fs) and fs.number<20:
     print(fs.filename,fs.current(toPIL=False))
-  e=time.clock()
+  e=time.process_time()
   print((e-b))

--- a/Fabian/rocker.py
+++ b/Fabian/rocker.py
@@ -53,11 +53,11 @@ class rocker:
 if __name__=='__main__':
   import sys,time
   from string import atoi
-  b=time.clock()
+  b=time.process_time()
   c=[atoi(sys.argv[4]),atoi(sys.argv[5]),atoi(sys.argv[6]),atoi(sys.argv[7])]
   R=rocker(filename_sample=sys.argv[1],coord=c,startnumber=atoi(sys.argv[2]),endnumber=atoi(sys.argv[3]))
   R.run()
   print(R.getdata())
-  e=time.clock()
+  e=time.process_time()
   print((e-b))
 


### PR DESCRIPTION
Fabian was using a call to time.clock() to process times. This function as been removed in Python3.8 

I replaced the calls to  time.clock() with time.process_time(). This is no impact on what is displayed and will run fine on newer python versions.
