### PR TITLE
Add runtime dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,13 @@ setup(
   url='http://fable.sourceforge.net',
   packages=['Fabian'],
   package_dir={"Fabian": "Fabian"},
-  scripts=["scripts/fabian.py", "scripts/collapse.py", "scripts/median.py"]
+  scripts=["scripts/fabian.py", "scripts/collapse.py", "scripts/median.py"],
+  install_requires=[
+    "pillow",
+    "pmw",
+    "pyopengltk",
+    "numpy",
+    "matplotlib",
+    "fabio"
+  ]
 )


### PR DESCRIPTION
Adds runtime dependencies (PMW, Fabio, etc etc) to `install_requires` in `setup.py`. Enables automated installation with `pip` and other tools without having to manually install dependencies first.